### PR TITLE
fix: mistyped sub_ecode and pte_width fixed

### DIFF
--- a/src/register/base/estat.rs
+++ b/src/register/base/estat.rs
@@ -65,8 +65,8 @@ impl Estat {
             0x7 => Trap::Exception(Exception::PagePrivilegeIllegal), //页特权级不合规
             0x8 => {
                 match sub_ecode {
-                    0x1 => Trap::Exception(Exception::FetchInstructionAddressError), //取指地址错误
-                    0x2 => Trap::Exception(Exception::MemoryAccessAddressError), //访存地址访问错误
+                    0x0 => Trap::Exception(Exception::FetchInstructionAddressError), //取指地址错误
+                    0x1 => Trap::Exception(Exception::MemoryAccessAddressError), //访存地址访问错误
                     _ => Trap::Unknown,
                 }
             }

--- a/src/register/mmu/pwcl.rs
+++ b/src/register/mmu/pwcl.rs
@@ -43,14 +43,14 @@ impl Pwcl {
         self.bits.get_bits(25..=29)
     }
 
-    /// Get the length of each page table entry in the memory. 0 - 64 bit; 1 - 128 bit; 2 - 192 bit; 3 - 256 bit.
+    /// Get the length of each page table entry in the memory. 0 - 64 bit; 1 - 128 bit; 2 - 256 bit; 3 - 512 bit.
     pub fn pte_width(&self) -> usize {
         let val = self.bits.get_bits(30..=31);
         match val {
             0 => 64 / 8,
             1 => 128 / 8,
-            2 => 192 / 8,
-            3 => 256 / 8,
+            2 => 256 / 8,
+            3 => 512 / 8,
             _ => panic!("invalid pte_width"),
         }
     }


### PR DESCRIPTION
根据手册修改了`estat.rs`中的subcode解析以及`pwcl.rs`中的pte_width宽度解析。

参考手册：《龙芯架构参考手册卷一:基础架构 V1.03（2023年4月）》P121与P111