### PR TITLE
feat(register/macros.rs): 为CSR实现From<usize> trait

### DIFF
--- a/src/register/macros.rs
+++ b/src/register/macros.rs
@@ -140,6 +140,12 @@ macro_rules! impl_define_csr {
                 self.bits
             }
         }
+
+        impl From<usize> for $csr_ident {
+            fn from(bits: usize) -> Self {
+                $csr_ident { bits }
+            }
+        }
     };
 }
 


### PR DESCRIPTION
用于把内核TrapFrame储存的寄存器值，转换为对应的csr的结构体